### PR TITLE
feat(roles): Restrict employee view to payroll, profile, and settings

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,7 +1,31 @@
+"use client"
+
+import { useEffect } from "react"
+import { useRouter } from "next/navigation"
+import { useAuth } from "@/contexts/auth-context"
 import { DashboardLayout } from "@/components/dashboard/dashboard-layout"
 import { DashboardOverview } from "@/components/dashboard/dashboard-overview"
 
 export default function HomePage() {
+  const { userProfile, loading } = useAuth()
+  const router = useRouter()
+
+  useEffect(() => {
+    if (!loading && userProfile?.role === "employee") {
+      router.replace("/payroll")
+    }
+  }, [userProfile, loading, router])
+
+  if (loading || userProfile?.role === "employee") {
+    return (
+      <DashboardLayout>
+        <div className="flex items-center justify-center h-full">
+          <p>Chargement...</p>
+        </div>
+      </DashboardLayout>
+    )
+  }
+
   return (
     <DashboardLayout>
       <DashboardOverview />

--- a/components/dashboard/dashboard-layout.tsx
+++ b/components/dashboard/dashboard-layout.tsx
@@ -42,7 +42,7 @@ const navigationItems = [
     href: "/",
     icon: BarChart3,
     current: true,
-    roles: ["super_admin", "hr_manager", "employee"], // All roles can access dashboard
+    roles: ["super_admin", "hr_manager"], // All roles can access dashboard
   },
   {
     name: "Entreprises",
@@ -56,21 +56,21 @@ const navigationItems = [
     href: "/employees",
     icon: Users,
     current: false,
-    roles: ["super_admin", "hr_manager", "employee"], // All roles but different scopes
+    roles: ["super_admin", "hr_manager"], // All roles but different scopes
   },
   {
     name: "Paie",
     href: "/payroll",
     icon: CreditCard,
     current: false,
-    roles: ["super_admin", "hr_manager"], // Only admins and HR can access payroll
+    roles: ["super_admin", "hr_manager", "employee"], // Only admins and HR can access payroll
   },
   {
     name: "Documents",
     href: "/documents",
     icon: FileText,
     current: false,
-    roles: ["super_admin", "hr_manager", "employee"], // All roles but different scopes
+    roles: ["super_admin", "hr_manager"], // All roles but different scopes
   },
   {
     name: "ScanPaie IA",


### PR DESCRIPTION
This commit refactors the user interface for the 'employee' role to align with the principle of least privilege.

The following changes have been made:
- Navigation items for 'Dashboard', 'Employees', and 'Documents' are now hidden for employees.
- The 'Payroll' navigation item is now visible to employees.
- Employees are now redirected from the dashboard overview page to the payroll page, as the overview is no longer relevant to their role.

These changes ensure that employees can only access features relevant to their needs, reducing clutter and potential confusion.